### PR TITLE
remove yarn-only postinstall checking script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "publish": "yarn build&&npm publish ./build",
     "lint": "polkadot-dev-run-lint",
     "clean": "polkadot-dev-clean-build",
-    "postinstall": "polkadot-dev-yarn-only",
     "test": "polkadot-dev-run-test --coverage --runInBand --testPathIgnorePatterns e2e",
     "test:one": "polkadot-dev-run-test",
     "test:watch": "polkadot-dev-run-test --watch"


### PR DESCRIPTION
This is a legacy kept from polkadot repository which uses yarn workspaces and demands yarn to be used